### PR TITLE
Fix: Unit 엔티티 수정

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "ko-KR"
+early_access: false
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - ".*"
+chat:
+  auto_reply: true

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ bin/
 *.iws
 *.iml
 *.ipr
-*.yml
+src/main/resources/*.yml
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/

--- a/src/main/java/com/stardy/poker_defense/unit/entity/BossUnit.java
+++ b/src/main/java/com/stardy/poker_defense/unit/entity/BossUnit.java
@@ -5,6 +5,8 @@ import com.stardy.poker_defense.round.entity.Round;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.Optional;
+
 @Builder
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -29,4 +31,18 @@ public class BossUnit {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id")
     private Game game;
+
+    private Integer hp;
+
+    private Integer defense;
+
+    private CardSuit suit;
+
+    private String number;
+
+    private Double xPos;
+
+    private Double yPos;
+
+    private UnitType type;
 }

--- a/src/main/java/com/stardy/poker_defense/unit/entity/EnemyUnit.java
+++ b/src/main/java/com/stardy/poker_defense/unit/entity/EnemyUnit.java
@@ -18,8 +18,6 @@ public class EnemyUnit {
     @Column(name = "enemy_unit_id")
     private Long id;
 
-    private Long systemUnitId;
-
     private Boolean killedYn;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -29,4 +27,18 @@ public class EnemyUnit {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "round_id")
     private Round round;
+
+    private Integer hp;
+
+    private Integer defense;
+
+    private CardSuit suit;
+
+    private String number;
+
+    private Double xPos;
+
+    private Double yPos;
+
+    private UnitType type;
 }

--- a/src/main/java/com/stardy/poker_defense/unit/entity/OwnedUnit.java
+++ b/src/main/java/com/stardy/poker_defense/unit/entity/OwnedUnit.java
@@ -17,9 +17,29 @@ public class OwnedUnit {
     @Column(name = "owned_unit_id")
     private Long id;
 
-    private Long systemUnitId;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_user_id")
     private GameUser gameUser;
+
+    private String name;
+
+    private Integer hp;
+
+    private Integer attackPower;
+
+    private Integer attackRange;
+
+    private CardSuit suit;
+
+    private String number;
+
+    private Double xPos;
+
+    private Double yPos;
+
+    private String zone; // boss or player
+
+    private UnitType type;
+
+    private Integer price;
 }

--- a/src/main/java/com/stardy/poker_defense/unit/entity/SystemUnit.java
+++ b/src/main/java/com/stardy/poker_defense/unit/entity/SystemUnit.java
@@ -20,19 +20,15 @@ public class SystemUnit {
 
     private Integer hp;
 
-    private Integer AttackPower;
+    private Integer attackPower;
 
-    private Integer AttackRange;
+    private Integer attackRange;
 
     private Integer defense;
 
     private CardSuit suit;
 
     private String number;
-
-    private Double xPos;
-
-    private Double yPos;
 
     private UnitType type;
 }


### PR DESCRIPTION
- 생성된 유닛 인스턴스 관련 정보들을 Enemy, Owned, Boss Unit들이 갖도록 수정
  - ex. SystemUnit의 hp는 해당 종류 유닛의 초기 hp, 나머지 유닛들의 hp는 현재 hp
- 각 유닛들 속성에 맞춰 컬럼 수정
  - ex. OwnedUnit은 hp, defense가 없음
- zone(현재 위치; 플레이어 존, 보스존), price 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - CodeRabbit AI 통합을 위한 설정 파일이 추가되었습니다.

- **버그 수정**
    - .gitignore 규칙이 변경되어, YAML 파일 무시 범위가 src/main/resources/ 디렉터리로 한정되었습니다.

- **리팩터**
    - 유닛 관련 엔티티에 체력, 방어력, 위치, 카드 정보 등 다양한 속성이 추가되어 데이터 표현이 확장되었습니다.
    - 일부 필드명 표기법이 표준에 맞게 수정되고, 불필요한 필드가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->