### PR TITLE
Feat: 방 시작 시 일어나는 과정 구현 중

### DIFF
--- a/src/main/java/com/stardy/poker_defense/PokerDefenseApplication.java
+++ b/src/main/java/com/stardy/poker_defense/PokerDefenseApplication.java
@@ -11,3 +11,5 @@ public class PokerDefenseApplication {
 	}
 
 }
+
+

--- a/src/main/java/com/stardy/poker_defense/common/config/WebSocketStompBrokerConfig.java
+++ b/src/main/java/com/stardy/poker_defense/common/config/WebSocketStompBrokerConfig.java
@@ -1,0 +1,26 @@
+package com.stardy.poker_defense.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketStompBrokerConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/sub");
+        config.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+
+        registry
+                .addEndpoint("/ws-stomp")
+                .setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/com/stardy/poker_defense/common/dto/MessageType.java
+++ b/src/main/java/com/stardy/poker_defense/common/dto/MessageType.java
@@ -1,0 +1,8 @@
+package com.stardy.poker_defense.common.dto;
+
+public enum MessageType {
+
+    ROUND_END,
+    ROUND_START,
+    TIMER,
+}

--- a/src/main/java/com/stardy/poker_defense/common/dto/RoundEndPayload.java
+++ b/src/main/java/com/stardy/poker_defense/common/dto/RoundEndPayload.java
@@ -1,0 +1,13 @@
+package com.stardy.poker_defense.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RoundEndPayload {
+    private Long userId;
+    private Integer lostLife;
+    private Integer remainEnemy;
+    private Integer lifeAfter;
+}

--- a/src/main/java/com/stardy/poker_defense/common/dto/RoundStartPayload.java
+++ b/src/main/java/com/stardy/poker_defense/common/dto/RoundStartPayload.java
@@ -1,0 +1,15 @@
+package com.stardy.poker_defense.common.dto;
+
+import com.stardy.poker_defense.common.service.WebsocketService;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RoundStartPayload {
+    private Long roundId;
+    private List<UnitInfoDto> enemyUnits;
+    private UnitInfoDto bossUnit;
+}

--- a/src/main/java/com/stardy/poker_defense/common/dto/TimerPayload.java
+++ b/src/main/java/com/stardy/poker_defense/common/dto/TimerPayload.java
@@ -1,0 +1,10 @@
+package com.stardy.poker_defense.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TimerPayload {
+    private Integer elapsedTime;
+}

--- a/src/main/java/com/stardy/poker_defense/common/dto/UnitInfoDto.java
+++ b/src/main/java/com/stardy/poker_defense/common/dto/UnitInfoDto.java
@@ -1,0 +1,51 @@
+package com.stardy.poker_defense.common.dto;
+
+import com.stardy.poker_defense.unit.entity.BossUnit;
+import com.stardy.poker_defense.unit.entity.CardSuit;
+import com.stardy.poker_defense.unit.entity.EnemyUnit;
+import com.stardy.poker_defense.unit.entity.UnitType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UnitInfoDto {
+
+    private Long id;
+    private Boolean killed;
+    private Integer hp;
+    private Integer defense;
+    private CardSuit suit;
+    private String number;
+    private Double xPos, yPos;
+    private UnitType type;
+
+    public static UnitInfoDto fromEnemyUnit(EnemyUnit eu) {
+        return UnitInfoDto.builder()
+                .id(eu.getId())
+                .killed(Boolean.TRUE.equals(eu.getKilledYn()))
+                .hp(eu.getHp())
+                .defense(eu.getDefense())
+                .suit(eu.getSuit())
+                .number(eu.getNumber())
+                .xPos(eu.getXPos())
+                .yPos(eu.getYPos())
+                .type(eu.getType())
+                .build();
+    }
+
+    public static UnitInfoDto fromBossUnit(BossUnit bu) {
+        if (bu == null) return null;
+        return UnitInfoDto.builder()
+                .id(bu.getId())
+                .killed(Boolean.TRUE.equals(bu.getKilledYn()))
+                .hp(bu.getHp())
+                .defense(bu.getDefense())
+                .suit(bu.getSuit())
+                .number(bu.getNumber())
+                .xPos(bu.getXPos())
+                .yPos(bu.getYPos())
+                .type(bu.getType())
+                .build();
+    }
+}

--- a/src/main/java/com/stardy/poker_defense/common/dto/WebsocketResponseDto.java
+++ b/src/main/java/com/stardy/poker_defense/common/dto/WebsocketResponseDto.java
@@ -1,0 +1,16 @@
+package com.stardy.poker_defense.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.awt.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class WebsocketResponseDto<T>{
+    private MessageType type;
+    private T payload;
+    private LocalDateTime timestamp;
+    private String roomId;
+}

--- a/src/main/java/com/stardy/poker_defense/common/service/WebsocketService.java
+++ b/src/main/java/com/stardy/poker_defense/common/service/WebsocketService.java
@@ -1,0 +1,157 @@
+package com.stardy.poker_defense.common.service;
+
+import com.stardy.poker_defense.common.dto.*;
+import com.stardy.poker_defense.game.entity.Game;
+import com.stardy.poker_defense.game.entity.GameUser;
+import com.stardy.poker_defense.room.entity.Room;
+import com.stardy.poker_defense.room.repository.RoomRepository;
+import com.stardy.poker_defense.round.entity.Round;
+import com.stardy.poker_defense.unit.entity.BossUnit;
+import com.stardy.poker_defense.unit.entity.EnemyUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.awt.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+import static java.lang.Thread.sleep;
+
+@RequiredArgsConstructor
+@Service
+public class WebsocketService {
+
+    @Value("${scheduler.threadpool-size}")
+    private int schedulerPoolSize;
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(schedulerPoolSize);
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    private final RoomRepository roomRepository;
+
+    public void startGame(Game game) {
+
+        List<Round> roundList = game.getRoundList();
+        if (roundList.isEmpty()) throw new RuntimeException("라운드 데이터가 없습니다.");
+
+        scheduler.execute(() -> {
+            try {
+                playRounds(game, roundList, game.getRoom().getId());
+
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private void playRounds(Game game, List<Round> roundList, Long roomId) throws InterruptedException {
+        for (Round round : roundList) {
+            // 1. 라운드 시작 알림 (적 유닛, 보스 정보 동시 전송)
+            sendRoundStart(round, roomId);
+
+            // 2. 라운드 타임루프 (예: 20초 or EnemyUnit, BossUnit 모두 killedYn==true 일 때까지 반복)
+            for (int sec = 1; sec <= 20; sec++) {
+                sendTimer(roomId, sec);
+
+                sleep(1000);
+
+                if (isRoundCleared(round)) break;
+            }
+
+            // 3. 라운드 종료: 유저별 미처치 적 수로 생명 차감하고 메시지 전송
+            settleRound(round, roomId);
+
+            sleep(2000);
+        }
+        // (전체 라운드 종료 후 게임 종료 메시지, 결과 집계 등을 추가하실 수 있습니다)
+    }
+
+    private void sendRoundStart(Round round, Long roomId) {
+        List<EnemyUnit> enemyUnits = round.getEnemyUnitList();
+        BossUnit bossUnit = round.getBossUnit();
+
+        List<UnitInfoDto> enemyDtoList = enemyUnits.stream()
+                .map(UnitInfoDto::fromEnemyUnit)
+                .collect(Collectors.toList());
+
+        UnitInfoDto bossDto = bossUnit != null ? UnitInfoDto.fromBossUnit(bossUnit) : null;
+
+        RoundStartPayload payload = RoundStartPayload.builder()
+                .roundId(round.getId())
+                .enemyUnits(enemyDtoList)
+                .bossUnit(bossDto)
+                .build();
+
+        WebsocketResponseDto<RoundStartPayload> wsMessage = WebsocketResponseDto.<RoundStartPayload>builder()
+                .type(MessageType.ROUND_START)
+                .payload(payload)
+                .timestamp(LocalDateTime.now())
+                .roomId(String.valueOf(roomId))
+                .build();
+
+        messagingTemplate.convertAndSend("/topic/game/" + roomId, wsMessage);
+
+        // 라운드 시작 시각도 기록
+        round.changeStartedAt(LocalDateTime.now());
+    }
+
+    private void sendTimer(Long roomId, int elapsedTime) {
+        TimerPayload timerPayload = TimerPayload.builder().elapsedTime(elapsedTime).build();
+
+        WebsocketResponseDto<TimerPayload> wsMessage = WebsocketResponseDto.<TimerPayload>builder()
+                .type(MessageType.TIMER)
+                .payload(timerPayload)
+                .timestamp(LocalDateTime.now())
+                .roomId(String.valueOf(roomId))
+                .build();
+
+        messagingTemplate.convertAndSend("/topic/game/" + roomId, wsMessage);
+    }
+
+    private boolean isRoundCleared(Round round) {
+        boolean enemiesCleared = round.getEnemyUnitList().stream().allMatch(e -> Boolean.TRUE.equals(e.getKilledYn()));
+        BossUnit boss = round.getBossUnit();
+        boolean bossCleared = (boss == null) || Boolean.TRUE.equals(boss.getKilledYn());
+        return enemiesCleared && bossCleared;
+    }
+
+    @Transactional
+    public void settleRound(Round round, Long roomId) {
+        Game game = round.getGame();
+        for (GameUser gameUser : game.getGameUserList()) {
+            long remain = round.getEnemyUnitList().stream()
+                    .filter(eu -> eu.getGameUser().equals(gameUser))
+                    .filter(eu -> !Boolean.TRUE.equals(eu.getKilledYn()))
+                    .count();
+            int oldLife = gameUser.getLife();
+            int lost = (int) remain;
+            int newLife = Math.max(oldLife - lost, 0);
+            gameUser.changeLife(newLife);
+
+            // 메시지 전송
+            RoundEndPayload payload = RoundEndPayload.builder()
+                    .userId(gameUser.getUser().getId())
+                    .lostLife(lost)
+                    .remainEnemy((int) remain)
+                    .lifeAfter(newLife)
+                    .build();
+            WebsocketResponseDto<RoundEndPayload> wsMessage = WebsocketResponseDto.<RoundEndPayload>builder()
+                    .type(MessageType.ROUND_END)
+                    .payload(payload)
+                    .timestamp(LocalDateTime.now())
+                    .roomId(String.valueOf(roomId))
+                    .build();
+            messagingTemplate.convertAndSend("/topic/room/" + roomId, wsMessage);
+        }
+
+        // 끝난 시각 기록
+        round.changeEndedAt(LocalDateTime.now());
+    }
+
+}

--- a/src/main/java/com/stardy/poker_defense/game/GameController.java
+++ b/src/main/java/com/stardy/poker_defense/game/GameController.java
@@ -1,0 +1,31 @@
+package com.stardy.poker_defense.game;
+
+import com.stardy.poker_defense.common.response.ApiResponse;
+import com.stardy.poker_defense.game.dto.StartGameRequestDto;
+import com.stardy.poker_defense.game.dto.StartGameResponseDto;
+import com.stardy.poker_defense.game.service.GameService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class GameController {
+
+    private final GameService gameService;
+
+    @PostMapping("/games")
+    public ResponseEntity<ApiResponse<Object>> startGame(@RequestBody StartGameRequestDto params) {
+
+        StartGameResponseDto result = gameService.startGame(params);
+
+        return ApiResponse.builder()
+                .data(null)
+                .status(HttpStatus.OK)
+                .message("게임이 시작되었습니다.")
+                .success();
+    }
+}

--- a/src/main/java/com/stardy/poker_defense/game/dto/StartGameRequestDto.java
+++ b/src/main/java/com/stardy/poker_defense/game/dto/StartGameRequestDto.java
@@ -1,0 +1,13 @@
+package com.stardy.poker_defense.game.dto;
+
+import com.stardy.poker_defense.game.entity.GameDifficultyLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class StartGameRequestDto {
+
+    private Long roomId;
+    private GameDifficultyLevel gameDifficultyLevel;
+}

--- a/src/main/java/com/stardy/poker_defense/game/dto/StartGameResponseDto.java
+++ b/src/main/java/com/stardy/poker_defense/game/dto/StartGameResponseDto.java
@@ -1,0 +1,19 @@
+package com.stardy.poker_defense.game.dto;
+
+import com.stardy.poker_defense.game.entity.Game;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StartGameResponseDto {
+
+    private Long gameId;
+
+    public static StartGameResponseDto from(Game game) {
+
+        return StartGameResponseDto.builder()
+                .gameId(game.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/stardy/poker_defense/game/entity/GameUser.java
+++ b/src/main/java/com/stardy/poker_defense/game/entity/GameUser.java
@@ -50,4 +50,8 @@ public class GameUser {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void changeLife(int life) {
+        this.life = life;
+    }
 }

--- a/src/main/java/com/stardy/poker_defense/game/service/GameService.java
+++ b/src/main/java/com/stardy/poker_defense/game/service/GameService.java
@@ -1,0 +1,8 @@
+package com.stardy.poker_defense.game.service;
+
+import com.stardy.poker_defense.game.dto.StartGameRequestDto;
+import com.stardy.poker_defense.game.dto.StartGameResponseDto;
+
+public interface GameService {
+    StartGameResponseDto startGame(StartGameRequestDto params);
+}

--- a/src/main/java/com/stardy/poker_defense/game/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/stardy/poker_defense/game/service/impl/GameServiceImpl.java
@@ -1,0 +1,65 @@
+package com.stardy.poker_defense.game.service.impl;
+
+import com.stardy.poker_defense.common.service.WebsocketService;
+import com.stardy.poker_defense.game.dto.StartGameRequestDto;
+import com.stardy.poker_defense.game.dto.StartGameResponseDto;
+import com.stardy.poker_defense.game.entity.Game;
+import com.stardy.poker_defense.game.entity.GameDifficultyLevel;
+import com.stardy.poker_defense.game.service.GameService;
+import com.stardy.poker_defense.room.entity.Room;
+import com.stardy.poker_defense.room.repository.RoomRepository;
+import com.stardy.poker_defense.round.entity.Round;
+import com.stardy.poker_defense.round.entity.SystemRound;
+import com.stardy.poker_defense.round.repository.SystemRoundRepository;
+import com.stardy.poker_defense.unit.entity.BossUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class GameServiceImpl implements GameService {
+
+    @Value("${game.round-info.normal-round}")
+    private int NORMAL_ROUND;
+
+    @Value("${game.round-info.hard-round}")
+    private int HARD_ROUND;
+
+    @Value("${game.round-info.hell-round}")
+    private int HELL_ROUND;
+
+    private final RoomRepository roomRepository;
+    private final SystemRoundRepository systemRoundRepository;
+
+    private final WebsocketService websocketService;
+
+    @Override
+    public StartGameResponseDto startGame(StartGameRequestDto params) {
+
+        Room room = roomRepository.findById(params.getRoomId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 방입니다."));
+
+//        if(params.getGameDifficultyLevel() == GameDifficultyLevel.NORMAL) {
+//
+//            List<SystemRound> systemRoundList = systemRoundRepository.findAllByRoundNumber(NORMAL_ROUND);
+//            for(SystemRound systemRound : systemRoundList) {
+//
+//                BossUnit bossUnit = systemRound.getBossRoundYn() == true ?
+//
+//                Round newRound = Round.builder()
+//                        .systemRoundId(systemRound.getId())
+//                        .game(room.getGame())
+//                        .
+//            }
+//        }
+
+        websocketService.startGame(room.getGame());
+
+        return StartGameResponseDto.from(room.getGame());
+    }
+}

--- a/src/main/java/com/stardy/poker_defense/room/repository/RoomRepository.java
+++ b/src/main/java/com/stardy/poker_defense/room/repository/RoomRepository.java
@@ -1,0 +1,7 @@
+package com.stardy.poker_defense.room.repository;
+
+import com.stardy.poker_defense.room.entity.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}

--- a/src/main/java/com/stardy/poker_defense/round/dto/request/CreateSystemRoundRequestDto.java
+++ b/src/main/java/com/stardy/poker_defense/round/dto/request/CreateSystemRoundRequestDto.java
@@ -11,5 +11,6 @@ public class CreateSystemRoundRequestDto {
     private Integer roundNumber;
     private Integer unitCount;
     private Boolean bossRoundYn;
-    private Long systemUnitId;
+    private Long systemNormalUnitId;
+    private Long systemBossUnitId;
 }

--- a/src/main/java/com/stardy/poker_defense/round/dto/response/GetSystemRoundListResponseDto.java
+++ b/src/main/java/com/stardy/poker_defense/round/dto/response/GetSystemRoundListResponseDto.java
@@ -9,7 +9,8 @@ import lombok.*;
 public class GetSystemRoundListResponseDto {
 
     private Integer roundNumber;
-    private Long systemUnitId;
+    private Long systemNormalUnitId;
+    private Long systemBossUnitId;
     private Integer unitCount;
     private Boolean bossRoundYn;
 }

--- a/src/main/java/com/stardy/poker_defense/round/entity/Round.java
+++ b/src/main/java/com/stardy/poker_defense/round/entity/Round.java
@@ -39,4 +39,12 @@ public class Round {
 
     @OneToOne(mappedBy = "round", fetch = FetchType.LAZY)
     private BossUnit bossUnit;
+
+    public void changeStartedAt(LocalDateTime startTime) {
+        this.startedAt = startTime;
+    }
+
+    public void changeEndedAt(LocalDateTime endTime) {
+        this.endedAt = endTime;
+    }
 }

--- a/src/main/java/com/stardy/poker_defense/round/entity/SystemRound.java
+++ b/src/main/java/com/stardy/poker_defense/round/entity/SystemRound.java
@@ -18,7 +18,9 @@ public class SystemRound {
 
     private Integer roundNumber;
 
-    private Long systemUnitId;
+    private Long systemNormalUnitId;
+
+    private Long systemBossUnitId;
 
     private Integer unitCount;
 

--- a/src/main/java/com/stardy/poker_defense/round/repository/SystemRoundRepository.java
+++ b/src/main/java/com/stardy/poker_defense/round/repository/SystemRoundRepository.java
@@ -2,11 +2,17 @@ package com.stardy.poker_defense.round.repository;
 
 import com.stardy.poker_defense.round.entity.SystemRound;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import javax.swing.text.html.Option;
+import java.util.List;
 import java.util.Optional;
 
 public interface SystemRoundRepository extends JpaRepository<SystemRound, Long> {
 
     Optional<SystemRound> findByRoundNumber(Integer roundNumber);
+
+    @Query("select sr from SystemRound sr where sr.roundNumber <= :normal_round")
+    List<SystemRound> findAllByRoundNumber(@Param("normal_round") Integer normal_round);
 }

--- a/src/main/java/com/stardy/poker_defense/round/service/impl/RoundServiceImpl.java
+++ b/src/main/java/com/stardy/poker_defense/round/service/impl/RoundServiceImpl.java
@@ -26,7 +26,8 @@ public class RoundServiceImpl implements RoundService {
         List<GetSystemRoundListResponseDto> resultList = systemRoundRepository.findAll().stream()
                 .map(sr -> GetSystemRoundListResponseDto.builder()
                         .roundNumber(sr.getRoundNumber())
-                        .systemUnitId(sr.getSystemUnitId())
+                        .systemNormalUnitId(sr.getSystemNormalUnitId())
+                        .systemBossUnitId(sr.getSystemBossUnitId())
                         .unitCount(sr.getUnitCount())
                         .bossRoundYn(sr.getBossRoundYn())
                         .build())
@@ -47,7 +48,8 @@ public class RoundServiceImpl implements RoundService {
                 .roundNumber(params.getRoundNumber())
                 .unitCount(params.getUnitCount())
                 .bossRoundYn(params.getBossRoundYn())
-                .systemUnitId(params.getSystemUnitId())
+                .systemNormalUnitId(params.getSystemNormalUnitId())
+                .systemBossUnitId(params.getSystemBossUnitId())
                 .build();
 
         systemRoundRepository.save(newSystemRound);

--- a/src/main/java/com/stardy/poker_defense/unit/entity/SystemUnit.java
+++ b/src/main/java/com/stardy/poker_defense/unit/entity/SystemUnit.java
@@ -26,9 +26,11 @@ public class SystemUnit {
 
     private Integer defense;
 
+    @Enumerated(EnumType.STRING)
     private CardSuit suit;
 
     private String number;
 
+    @Enumerated(EnumType.STRING)
     private UnitType type;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 게임 시작 및 라운드 진행을 위한 REST API 및 WebSocket 실시간 메시징 기능이 추가되었습니다.
  * 게임 라운드, 유닛, 타이머 등 다양한 상황에 대한 메시지 타입 및 페이로드 DTO가 도입되었습니다.
  * 게임 시작 요청 및 응답, 라운드 정보, 유닛 정보 등 관련 DTO 및 서비스가 추가되었습니다.

* **기능 개선**
  * 라운드 및 시스템 라운드 관련 엔티티와 DTO에서 일반 유닛과 보스 유닛 ID를 분리하여 관리하도록 구조가 개선되었습니다.
  * 유닛의 suit, type 필드가 데이터베이스에 문자열로 저장되도록 변경되었습니다.

* **버그 수정**
  * 없음

* **기타**
  * WebSocket 및 STOMP 브로커 설정이 추가되어 실시간 통신이 활성화되었습니다.
  * 일부 엔티티에 편의 메서드 및 어노테이션이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->